### PR TITLE
Don't publish `*.spec.d.ts` and `*.test.d.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Will no longer publish `*.spec.*` and `*.test.*` to NPM, by [@compulim](https://github.com/compulim), in PR [#6](https://github.com/compulim/react-wrap-with/pull/6)
+- Will no longer publish `*.spec.*` and `*.test.*` to NPM, by [@compulim](https://github.com/compulim), in PR [#6](https://github.com/compulim/react-wrap-with/pull/6) and PR [#7](https://github.com/compulim/react-wrap-with/pull/7)
 - Bump dependencies, by [@compulim](https://github.com/compulim), in PR [#3](https://github.com/compulim/react-wrap-with/pull/3)
    -  Production dependencies
       -  [`@babel/runtime-corejs3@7.21.0`](https://npmjs.com/package/@babel/runtime-corejs3)

--- a/packages/react-wrap-with/package.json
+++ b/packages/react-wrap-with/package.json
@@ -42,9 +42,11 @@
     "url": "git+https://github.com/compulim/react-wrap-with.git"
   },
   "keywords": [
-    "react",
-    "react-hook",
-    "react-hooks"
+    "higher order",
+    "hoc",
+    "hook",
+    "hooks",
+    "react"
   ],
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",

--- a/packages/react-wrap-with/src/tsconfig.json
+++ b/packages/react-wrap-with/src/tsconfig.json
@@ -3,5 +3,6 @@
     "esModuleInterop": true,
     "jsx": "react",
     "strict": true
-  }
+  },
+  "exclude": ["**/*.spec.*", "**/*.test.*"]
 }


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Will no longer publish `*.spec.*` and `*.test.*` to NPM, by [@compulim](https://github.com/compulim), in PR [#6](https://github.com/compulim/react-wrap-with/pull/6) and PR [#7](https://github.com/compulim/react-wrap-with/pull/7)

## Specific changes

> Please list each individual specific change in this pull request.

- Update `tsconfig.json/exclude` to exclude test files