### PR TITLE
Forward ref to inner component

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,8 +8,18 @@ extends:
 overrides:
   - extends: .eslintrc.jest.yml
     files:
+    - '__tests__/**'
+    - '__tests__/**'
+    - '__tests__/**'
+    - '__tests__/**'
     - '*.spec.js'
+    - '*.spec.jsx'
+    - '*.spec.ts'
+    - '*.spec.tsx'
     - '*.test.js'
+    - '*.test.jsx'
+    - '*.test.ts'
+    - '*.test.tsx'
 parser: '@typescript-eslint/parser'
 parserOptions:
   ecmaVersion: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Extract props during render and pass to the wrapper component, by [@compulim](https://github.com/compulim), in PR [#4](https://github.com/compulim/react-wrap-with/pull/4) and [#5](https://github.com/compulim/react-wrap-with/pull/5)
+- Extracts props during render and pass to the wrapper component, by [@compulim](https://github.com/compulim), in PR [#4](https://github.com/compulim/react-wrap-with/pull/4) and [#5](https://github.com/compulim/react-wrap-with/pull/5)
+- Forwards ref to the inner component, by [@compulim](https://github.com/compulim), in PR [#8](https://github.com/compulim/react-wrap-with/pull/8)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # `react-wrap-with`
 
-Wrap a React component in another component by Higher-Order Component.
+Creates higher-order component for wrapping component in another component.
 
 ## Background
 
 When using React Context, sometimes it is inevitable to create an intermediate component to consume the context.
 
-This function will wrap as an intermediate component and reduce complexity in the code.
+This function will wrap as an intermediate component and reduce code complexity.
 
 ## How to use
 
@@ -47,6 +47,10 @@ Sometimes, instead of initializing props during setup, you can extract and pass 
 - createRoot(document.getElementById('root')).render(<Hello />);
 + createRoot(document.getElementById('root')).render(<Hello effect="blink" />); // Specifying "effect" prop during render.
 ```
+
+### Referencing
+
+Refs are automatically forwarded to the inner component.
 
 ## API
 

--- a/packages/react-wrap-with/__tests__/types/fail/ref.wrongType.tsx
+++ b/packages/react-wrap-with/__tests__/types/fail/ref.wrongType.tsx
@@ -1,0 +1,16 @@
+import React, { forwardRef } from 'react';
+
+import wrapWith from '../../../src/wrapWith';
+
+import type { ReactNode, Ref } from 'react';
+
+const Header = ({ children }: { children?: ReactNode | undefined }) => <h1>{children}</h1>;
+
+const Bold = forwardRef<HTMLDivElement, { children?: ReactNode | undefined }>(({ children }, ref) => (
+  <div ref={ref}>{children}</div>
+));
+
+const Wrapped = wrapWith(Header)(Bold);
+
+// THEN: It should throw "Type 'HTMLDivElement' is not assignable to type 'string'."
+<Wrapped ref={(() => {}) as Ref<string>} />;

--- a/packages/react-wrap-with/__tests__/types/ref.tsx
+++ b/packages/react-wrap-with/__tests__/types/ref.tsx
@@ -1,0 +1,17 @@
+import React, { forwardRef } from 'react';
+
+import wrapWith from '../../src/wrapWith';
+
+import type { ReactNode, Ref } from 'react';
+
+const Header = ({ children }: { children?: ReactNode | undefined }) => <h1>{children}</h1>;
+
+const Bold = forwardRef<HTMLDivElement, { children?: ReactNode | undefined }>(({ children }, ref) => (
+  <div ref={ref}>{children}</div>
+));
+
+// WHEN: Creating a component with ref of HTMLDivElement.
+const Wrapped = wrapWith(Header)(Bold);
+
+// THEN: It should compile.
+<Wrapped ref={(() => {}) as Ref<HTMLDivElement>} />;

--- a/packages/react-wrap-with/package.json
+++ b/packages/react-wrap-with/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-wrap-with",
   "version": "0.0.0-0",
-  "description": "Creates React higher-order component by wrapping with a container component.",
+  "description": "Creates higher-order component for wrapping component in another component.",
   "files": [
     "./lib/*"
   ],

--- a/packages/react-wrap-with/src/wrapWith.displayName.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.displayName.spec.tsx
@@ -1,7 +1,6 @@
 /** @jest-environment jsdom */
 /// <reference types="@types/jest" />
 
-import { render } from '@testing-library/react';
 import React from 'react';
 
 import wrapWith from './wrapWith';
@@ -12,17 +11,14 @@ type EffectProps = PropsWithChildren<{ effect: 'blink' }>;
 
 const Effect = ({ children, effect }: EffectProps) => <span className={`effect effect--${effect}`}>{children}</span>;
 
+Effect.displayName = 'Effect';
+
 const Hello = () => <h1>Hello, World!</h1>;
 
 test('simple scenario', () => {
-  // GIVEN: Wrapping <Hello> with <Effect effect="blink">.
+  // WHEN: Wrapping <Hello> with <Effect effect="blink">.
   const BlinkingHello = wrapWith(Effect, { effect: 'blink' })(Hello);
 
-  // WHEN: Render.
-  const result = render(<BlinkingHello />);
-
-  // THEN: It should produce HTML equivalent to <Effect><Hello /></Effect>.
-  expect(result.container.innerHTML).toMatchInlineSnapshot(
-    `"<span class="effect effect--blink"><h1>Hello, World!</h1></span>"`
-  );
+  // THEN: Wrapped component should have display name of "WrappedWithEffect".
+  expect(BlinkingHello).toHaveProperty('displayName', 'WrappedWithEffect');
 });

--- a/packages/react-wrap-with/src/wrapWith.extract.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.extract.spec.tsx
@@ -1,4 +1,5 @@
 /** @jest-environment jsdom */
+/// <reference types="@types/jest" />
 
 import { render } from '@testing-library/react';
 import React from 'react';

--- a/packages/react-wrap-with/src/wrapWith.noProps.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.noProps.spec.tsx
@@ -1,4 +1,5 @@
 /** @jest-environment jsdom */
+/// <reference types="@types/jest" />
 
 import { render } from '@testing-library/react';
 import React from 'react';

--- a/packages/react-wrap-with/src/wrapWith.refCallback.classComponent.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.refCallback.classComponent.spec.tsx
@@ -1,0 +1,60 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { render } from '@testing-library/react';
+import React, { Component } from 'react';
+
+import wrapWith from './wrapWith';
+
+import type { PropsWithChildren, Ref } from 'react';
+
+type EffectProps = PropsWithChildren<{ containerRef?: Ref<HTMLSpanElement>; effect: 'blink' }>;
+
+class Effect extends Component<EffectProps> {
+  render() {
+    const { children, containerRef, effect } = this.props;
+
+    return (
+      <span className={`effect effect--${effect}`} ref={containerRef}>
+        {children}
+      </span>
+    );
+  }
+}
+
+class Hello extends Component {
+  render() {
+    return <h1>Hello, World!</h1>;
+  }
+}
+
+test('ref of RefObject should be passed', () => {
+  // GIVEN: Wrapping <Hello> with <Effect effect="blink">.
+  const BlinkingHello = wrapWith(Effect, { effect: 'blink' }, ['containerRef'])(Hello);
+
+  const App = ({
+    onContainerRef,
+    onRef
+  }: {
+    onContainerRef: (ref: HTMLSpanElement) => void;
+    onRef: (ref: HTMLHeadingElement) => void;
+  }) => <BlinkingHello containerRef={onContainerRef} ref={onRef} />;
+
+  const handleRef = jest.fn();
+  const handleContainerRef = jest.fn();
+
+  // WHEN: Render.
+  render(<App onContainerRef={handleContainerRef} onRef={handleRef} />);
+
+  // THEN: "containerRef" should be passed.
+  expect(handleContainerRef).toBeCalledTimes(1);
+
+  // THEN: "containerRef" should point to <span>.
+  expect(handleContainerRef.mock.calls[0][0]).toHaveProperty('tagName', 'SPAN');
+
+  // THEN: "ref" should be passed.
+  expect(handleRef).toBeCalledTimes(1);
+
+  // THEN: "ref" should point to <Hello>.
+  expect(handleRef.mock.calls[0][0]).toBeInstanceOf(Hello);
+});

--- a/packages/react-wrap-with/src/wrapWith.refCallback.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.refCallback.spec.tsx
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { render } from '@testing-library/react';
+import React, { forwardRef } from 'react';
+
+import wrapWith from './wrapWith';
+
+import type { PropsWithChildren, Ref } from 'react';
+
+type EffectProps = PropsWithChildren<{ effect: 'blink' }>;
+
+const Effect = forwardRef(({ children, effect }: EffectProps, ref: Ref<HTMLSpanElement> | null) => (
+  <span className={`effect effect--${effect}`} ref={ref}>
+    {children}
+  </span>
+));
+
+Effect.displayName = 'Effect';
+
+const Hello = forwardRef((_, ref: Ref<HTMLHeadingElement>) => <h1 ref={ref}>Hello, World!</h1>);
+
+Hello.displayName = 'Hello';
+
+test('ref of RefObject should be passed', () => {
+  // GIVEN: Wrapping <Hello> with <Effect effect="blink">.
+  const BlinkingHello = wrapWith(Effect, { effect: 'blink' })(Hello);
+
+  const App = ({ onRef }: { onRef: (htmlElement: HTMLHeadingElement) => void }) => <BlinkingHello ref={onRef} />;
+
+  // WHEN: Render.
+  const handleRef = jest.fn();
+
+  render(<App onRef={handleRef} />);
+
+  // THEN: Ref should be passed.
+  expect(handleRef).toBeCalledTimes(1);
+
+  // THEN: Ref should point to <h1>.
+  expect(handleRef.mock.calls[0][0]).toHaveProperty('tagName', 'H1');
+});

--- a/packages/react-wrap-with/src/wrapWith.refObject.classComponent.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.refObject.classComponent.spec.tsx
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { render } from '@testing-library/react';
+import React, { Component, forwardRef, useEffect, useRef } from 'react';
+
+import wrapWith from './wrapWith';
+
+import type { PropsWithChildren, Ref } from 'react';
+
+type EffectProps = PropsWithChildren<{ containerRef?: Ref<HTMLSpanElement>; effect: 'blink' }>;
+
+class Effect extends Component<EffectProps> {
+  render() {
+    const { children, containerRef, effect } = this.props;
+
+    return (
+      <span className={`effect effect--${effect}`} ref={containerRef}>
+        {children}
+      </span>
+    );
+  }
+}
+
+class Hello extends Component {
+  render() {
+    return <h1>Hello, World!</h1>;
+  }
+}
+
+test('ref of RefObject should be passed', () => {
+  // GIVEN: Wrapping <Hello> with <Effect effect="blink">.
+  const BlinkingHello = wrapWith(Effect, { effect: 'blink' }, ['containerRef'])(Hello);
+
+  const App = ({ onRef }: { onRef: (refs: [HTMLSpanElement | null, Hello | undefined]) => void }) => {
+    const containerRef = useRef<HTMLSpanElement | null>(null);
+    const ref = useRef<Hello>();
+
+    useEffect(() => onRef([containerRef.current, ref.current]), [onRef]);
+
+    return <BlinkingHello containerRef={containerRef} ref={ref} />;
+  };
+
+  const handleRef = jest.fn();
+
+  // WHEN: Render.
+  render(<App onRef={handleRef} />);
+
+  // THEN: Ref should be passed.
+  expect(handleRef).toBeCalledTimes(1);
+
+  // THEN: "containerRef" is pointing to the instance of <span>.
+  expect(handleRef.mock.calls[0][0][0]).toHaveProperty('tagName', 'SPAN');
+
+  // THEN: "ref" is pointing to the instance of <Hello>.
+  expect(handleRef.mock.calls[0][0][1]).toBeInstanceOf(Hello);
+});

--- a/packages/react-wrap-with/src/wrapWith.refObject.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.refObject.spec.tsx
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { render } from '@testing-library/react';
+import React, { forwardRef, useEffect, useRef } from 'react';
+
+import wrapWith from './wrapWith';
+
+import type { PropsWithChildren, Ref } from 'react';
+
+type EffectProps = PropsWithChildren<{ containerRef?: Ref<HTMLSpanElement>; effect: 'blink' }>;
+
+const Effect = ({ children, containerRef, effect }: EffectProps) => (
+  <span className={`effect effect--${effect}`} ref={containerRef}>
+    {children}
+  </span>
+);
+
+Effect.displayName = 'Effect';
+
+const Hello = forwardRef((_, ref: Ref<HTMLHeadingElement>) => <h1 ref={ref}>Hello, World!</h1>);
+
+Hello.displayName = 'Effect';
+
+test('ref of RefObject should be passed', () => {
+  // GIVEN: Wrapping <Hello> with <Effect effect="blink">.
+  const BlinkingHello = wrapWith(Effect, { effect: 'blink' }, ['containerRef'])(Hello);
+
+  const App = ({ onRef }: { onRef: (refs: [HTMLDivElement | null, HTMLHeadingElement | null]) => void }) => {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const ref = useRef<HTMLHeadingElement | null>(null);
+
+    useEffect(() => onRef([containerRef.current, ref.current]), [onRef]);
+
+    return <BlinkingHello containerRef={containerRef} ref={ref} />;
+  };
+
+  const handleRef = jest.fn();
+
+  // WHEN: Render.
+  render(<App onRef={handleRef} />);
+
+  // THEN: Ref should be passed.
+  expect(handleRef).toBeCalledTimes(1);
+
+  // THEN: "containerRef" should point to <span>.
+  expect(handleRef.mock.calls[0][0][0]).toHaveProperty('tagName', 'SPAN');
+
+  // THEN: "ref" should point to <h1>.
+  expect(handleRef.mock.calls[0][0][1]).toHaveProperty('tagName', 'H1');
+});

--- a/packages/react-wrap-with/src/wrapWith.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.spec.tsx
@@ -1,4 +1,5 @@
 /** @jest-environment jsdom */
+/// <reference types="@types/jest" />
 
 import { render } from '@testing-library/react';
 import React from 'react';


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Forwards ref to the inner component, by [@compulim](https://github.com/compulim), in PR [#8](https://github.com/compulim/react-wrap-with/pull/8)

## Specific changes

> Please list each individual specific change in this pull request.

- Add `forwardRef` to forward ref to the inner component