### PR TITLE
Rename wrapper/wrapped to container/content

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Will produce the HTML:
 
 ### Extracting props
 
-Sometimes, instead of initializing props during setup, you can extract and pass specific props into the wrapper component during render.
+Sometimes, instead of initializing props during setup, you can extract and pass specific props into the container component during render.
 
 ```diff
   import { createRoot } from 'react-render';
@@ -40,7 +40,7 @@ Sometimes, instead of initializing props during setup, you can extract and pass 
 
   const Effect = ({ children, effect }) => <span className={`effect effect--${effect}`}>{children}</span>;
 - const withEffect = wrapWith(Effect, { effect: 'blink' });
-+ const withEffect = wrapWith(Effect, {}, ['effect']); // "effect" prop will be extracted during render and passed to the wrapper component <Effect>.
++ const withEffect = wrapWith(Effect, {}, ['effect']); // "effect" prop will be extracted during render and passed to the container component <Effect>.
 
   const Hello = withEffect(() => <h1>Hello</h1>);
 
@@ -55,25 +55,30 @@ Refs are automatically forwarded to the inner component.
 ## API
 
 ```ts
-function wrapWith<
-  Wrapper extends ComponentType<PropsWithChildren<any>>,
-  ExtractPropKey extends keyof PropsOf<Wrapper> = never
->(
-  WrapperComponent: Wrapper | false | null | undefined,
-  wrapperProps?: Omit<PropsOf<Wrapper>, ExtractPropKey>,
+import { ComponentType } from 'react';
+
+type ContainerProps = {};
+type ContainerComponentType = ComponentType<ContainerProps>;
+
+type ContentProps = {};
+type ContentComponentType = ComponentType<ContentProps>;
+
+function wrapWith(
+  ContainerComponent: ContainerComponentType | false | null | undefined,
+  initialProps?: Omit<ContainerProps, ExtractPropKey>,
   extractPropKeys: ExtractPropKey[] = []
 ): (
-  WrappedComponent: Wrapped | false | null | undefined
-) => ComponentType<Pick<PropsOf<Wrapper>, ExtractPropKey> & PropsOf<Wrapped>>;
+  ContentComponent: ContentComponentType | false | null | undefined
+) => ComponentType<Pick<ContainerProps, ExtractPropKey> & ContentProps & { ref?: Ref }>;
 ```
 
 ## Behaviors
 
-### TypeScript: All wrappers must have props of `children`
+### TypeScript: All containers must have props of `children`
 
-Wrappers must allow `children` props. This is because wrapper is going to wrap around another component in parent-child relationship.
+Containers must allow `children` props. This is because container is going to wrap around another component in parent-child relationship.
 
-If you are seeing the following error in TypeScript, please make sure the wrapper component allow `children` props. `React.PropsWithChildren<>` is a typing helper to add `children` to any props.
+If you are seeing the following error in TypeScript, please make sure the container component allow `children` props. `React.PropsWithChildren<>` is a helper type to add `children` to any props. If the component does not have props, use this prop type: `{ children?: ReactNode }`.
 
 ```
 Argument of type 'FC<Props>' is not assignable to parameter of type 'false | ComponentType<PropsWithChildren<EmptyProps>> | null | undefined'.

--- a/packages/react-wrap-with/__tests__/types/extractProps.optionalProp.empty.tsx
+++ b/packages/react-wrap-with/__tests__/types/extractProps.optionalProp.empty.tsx
@@ -8,7 +8,7 @@ const Header = ({ children, className }: PropsWithChildren<{ className?: string 
   <h1 className={className}>{children}</h1>
 );
 
-// Because "className" is extracted, it should be okay to pass {} for wrapperProps.
+// Because "className" is extracted, it should be okay to pass {} for initialProps.
 const Component = wrapWith(Header, {}, ['className'])(() => <div />);
 
 // It is okay to render without "className" prop because "className" prop is optional.

--- a/packages/react-wrap-with/__tests__/types/extractProps.optionalProp.undefined.tsx
+++ b/packages/react-wrap-with/__tests__/types/extractProps.optionalProp.undefined.tsx
@@ -8,7 +8,7 @@ const Header = ({ children, className }: PropsWithChildren<{ className?: string 
   <h1 className={className}>{children}</h1>
 );
 
-// Because "className" is extracted, it should be okay to pass undefined for wrapperProps.
+// Because "className" is extracted, it should be okay to pass undefined for initialProps.
 const Component = wrapWith(Header, undefined, ['className'])(() => <div />);
 
 // It is okay to render without "className" prop because "className" prop is optional.

--- a/packages/react-wrap-with/__tests__/types/fail/noChildren.tsx
+++ b/packages/react-wrap-with/__tests__/types/fail/noChildren.tsx
@@ -8,5 +8,5 @@ type Props = { className: string };
 
 const Header: FC<Props> = () => <h1>Hello, World!</h1>;
 
-// All wrappers must allow "children" prop.
+// All containers must allow "children" prop.
 wrapWith(Header);

--- a/packages/react-wrap-with/src/wrapWith.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.spec.tsx
@@ -51,9 +51,9 @@ describe('Wrapping <ListItem> with <OrderedList>', () => {
   });
 });
 
-test.each([false, null, undefined] as [false, null, undefined])('wrapping <ListItem> with `%s`', wrapper => {
+test.each([false, null, undefined] as [false, null, undefined])('wrapping <ListItem> with `%s`', ContainerComponent => {
   // GIVEN: Wrapping <ListItem> with false/null/undefined.
-  const Wrapped = wrapWith(wrapper, {})(ListItem);
+  const Wrapped = wrapWith(ContainerComponent, {})(ListItem);
 
   // WHEN: When rendering the wrapped component.
   const result = render(<Wrapped>Hello, World!</Wrapped>);
@@ -88,9 +88,9 @@ test.each([false, null, undefined] as [false, null, undefined])('wrapping `%s` w
 
 test.each([false, null, undefined] as [false, null, undefined])(
   'wrapping `%s` with the same type of component',
-  wrapperAndWrapping => {
+  ComponentComponent => {
     // GIVEN: Wrapping false/null/undefined with false/null/undefined.
-    const Wrapped = wrapWith(wrapperAndWrapping, {})(wrapperAndWrapping);
+    const Wrapped = wrapWith(ComponentComponent, {})(ComponentComponent);
 
     // WHEN: Rendering the wrapped component.
     const result = render(<Wrapped>Hello, World!</Wrapped>);

--- a/packages/react-wrap-with/src/wrapWith.tsx
+++ b/packages/react-wrap-with/src/wrapWith.tsx
@@ -11,87 +11,98 @@ const EmptyComponent = () => <Fragment />;
 
 export default function wrapWith<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Wrapper extends ComponentType<PropsWithChildren<any>>,
-  ExtractPropKey extends keyof Omit<PropsOf<Wrapper>, 'children'> = never
+  ContainerComponentType extends ComponentType<PropsWithChildren<any>>,
+  ExtractPropKey extends keyof Omit<PropsOf<ContainerComponentType>, 'children'> = never
 >(
-  WrapperComponent: Wrapper | false | null | undefined,
-  wrapperProps: Omit<PropsOf<Wrapper> & { children?: never }, ExtractPropKey> | undefined,
+  ContainerComponent: ContainerComponentType | false | null | undefined,
+  initialProps: Omit<PropsOf<ContainerComponentType> & { children?: never }, ExtractPropKey> | undefined,
   extractPropKeys: ExtractPropKey[]
   // @types/react did not put a restrictions on what can be props.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): <Wrapped extends ComponentType<any>, Ref = RefOf<PropsOf<Wrapped>>>(
-  WrappedComponent: Wrapped | false | null | undefined
-) => ComponentType<PropsWithoutRef<Pick<PropsOf<Wrapper>, ExtractPropKey> & PropsOf<Wrapped>> & RefAttributes<Ref>>;
+): <ContentComponentType extends ComponentType<any>, Ref = RefOf<PropsOf<ContentComponentType>>>(
+  ContentComponent: ContentComponentType | false | null | undefined
+) => ComponentType<
+  PropsWithoutRef<Pick<PropsOf<ContainerComponentType>, ExtractPropKey> & PropsOf<ContentComponentType>> &
+    RefAttributes<Ref>
+>;
 
 export default function wrapWith<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Wrapper extends ComponentType<PropsWithChildren<any>>
+  ContainerComponentType extends ComponentType<PropsWithChildren<any>>
 >(
-  WrapperComponent: Wrapper | false | null | undefined,
+  ContainerComponent: ContainerComponentType | false | null | undefined,
   // There is a bug in TypeScript that Omit<T, never> & Partial<Pick<T>, never>> does not equals to T.
-  wrapperProps: PropsOf<Wrapper> & { children?: never },
+  initialProps: PropsOf<ContainerComponentType> & { children?: never },
   extractedPropKeys?: undefined
   // @types/react did not put a restrictions on what can be props.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): <Wrapped extends ComponentType<any>, Ref = RefOf<PropsOf<Wrapped>>>(
-  WrappedComponent: Wrapped | false | null | undefined
-) => ComponentType<PropsWithoutRef<PropsOf<Wrapped>> & RefAttributes<Ref>>;
+): <ContentComponentType extends ComponentType<any>, Ref = RefOf<PropsOf<ContentComponentType>>>(
+  ContentComponent: ContentComponentType | false | null | undefined
+) => ComponentType<PropsWithoutRef<PropsOf<ContentComponentType>> & RefAttributes<Ref>>;
 
-// If Wrapper need no props other than children, wrapperProps is optional.
+// If <Container> need no props other than children, initialProps is optional.
 export default function wrapWith<
-  Wrapper extends ComponentType<{ children?: ReactNode | undefined }> | false | null | undefined
+  ContainerComponentType extends ComponentType<{ children?: ReactNode | undefined }> | false | null | undefined
 >(
-  WrapperComponent: Wrapper | false | null | undefined,
-  wrapperProps?: undefined | Record<number | string | symbol, never>
+  ContainerComponent: ContainerComponentType | false | null | undefined,
+  initialProps?: undefined | Record<number | string | symbol, never>
   // @types/react did not put a restrictions on what can be props.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): <Wrapped extends ComponentType<any>, Ref = RefOf<PropsOf<Wrapped>>>(
-  WrappedComponent: Wrapped | false | null | undefined
-) => ComponentType<PropsWithoutRef<PropsOf<Wrapped>> & RefAttributes<Ref>>;
+): <ContentComponentType extends ComponentType<any>, Ref = RefOf<PropsOf<ContentComponentType>>>(
+  ContentComponent: ContentComponentType | false | null | undefined
+) => ComponentType<PropsWithoutRef<PropsOf<ContentComponentType>> & RefAttributes<Ref>>;
 
 export default function wrapWith<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Wrapper extends ComponentType<PropsWithChildren<any>>,
-  ExtractPropKey extends keyof Omit<PropsOf<Wrapper>, 'children'> = never
+  ContainerComponentType extends ComponentType<PropsWithChildren<any>>,
+  ExtractPropKey extends keyof Omit<PropsOf<ContainerComponentType>, 'children'> = never
 >(
-  WrapperComponent: Wrapper | false | null | undefined,
-  wrapperProps?: Omit<PropsOf<Wrapper> & { children?: never }, ExtractPropKey>,
+  ContainerComponent: ContainerComponentType | false | null | undefined,
+  initialProps?: Omit<PropsOf<ContainerComponentType> & { children?: never }, ExtractPropKey>,
   extractPropKeys: ExtractPropKey[] = [] as never[]
 ) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function wrap<Wrapped extends ComponentType<any>, Ref = RefOf<PropsOf<Wrapped>>>(
-    WrappedComponent: Wrapped | false | null | undefined
-  ): ComponentType<PropsWithoutRef<Pick<PropsOf<Wrapper>, ExtractPropKey> & PropsOf<Wrapped>> & RefAttributes<Ref>> {
-    if (WrapperComponent) {
-      const WithWrapper = forwardRef<Ref, Pick<PropsOf<Wrapper>, ExtractPropKey> & PropsOf<Wrapped>>((props, ref) => {
-        const [extractedProps, wrappedProps] = pickAndOmit<
-          Pick<PropsOf<Wrapper>, ExtractPropKey>,
-          PropsOf<Wrapped> & { ref?: Ref }
+  return function wrap<ContentComponentType extends ComponentType<any>, Ref = RefOf<PropsOf<ContentComponentType>>>(
+    ContentComponent: ContentComponentType | false | null | undefined
+  ): ComponentType<
+    PropsWithoutRef<Pick<PropsOf<ContainerComponentType>, ExtractPropKey> & PropsOf<ContentComponentType>> &
+      RefAttributes<Ref>
+  > {
+    if (ContainerComponent) {
+      const WithContainer = forwardRef<
+        Ref,
+        Pick<PropsOf<ContainerComponentType>, ExtractPropKey> & PropsOf<ContentComponentType>
+      >((props, ref) => {
+        const [extractedProps, contentProps] = pickAndOmit<
+          Pick<PropsOf<ContainerComponentType>, ExtractPropKey>,
+          PropsOf<ContentComponentType> & { ref?: Ref }
         >(props, extractPropKeys);
 
         return createElement(
-          WrapperComponent,
-          { ...wrapperProps, ...extractedProps },
-          // If there are no "WrappedComponent", don't override children. It will override the `props.children`.
+          ContainerComponent,
+          { ...initialProps, ...extractedProps },
+          // If there are "ContentComponentType" is falsy, don't override children. It will override the `props.children`.
           // False positive: we are unpacking the array rightaway.
           // eslint-disable-next-line react/jsx-key
-          ...(WrappedComponent ? [createElement(WrappedComponent, { ...wrappedProps, ref })] : [])
+          ...(ContentComponent
+            ? [createElement<PropsOf<ContentComponentType>>(ContentComponent, { ...contentProps, ref })]
+            : [])
         );
       });
 
-      WithWrapper.displayName = `WrappedWith${WrapperComponent.displayName || 'Component'}`;
+      WithContainer.displayName = `WrappedWith${ContainerComponent.displayName || 'Component'}`;
 
-      return WithWrapper;
+      return WithContainer;
     }
 
-    if (WrappedComponent) {
-      const WithWrapper = forwardRef<Ref, PropsOf<Wrapped>>((props, ref) =>
-        createElement<PropsOf<Wrapped>>(WrappedComponent, { ...props, ref })
+    if (ContentComponent) {
+      const WithContainer = forwardRef<Ref, PropsOf<ContentComponentType>>((props, ref) =>
+        createElement<PropsOf<ContentComponentType>>(ContentComponent, { ...props, ref })
       );
 
-      WithWrapper.displayName = WrappedComponent.displayName;
+      WithContainer.displayName = ContentComponent.displayName;
 
-      return WithWrapper;
+      return WithContainer;
     }
 
     return EmptyComponent;


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Terminology changed from "wrapper"/"wrapped" to "container"/"content", by [@compulim](https://github.com/compulim), in PR [#10](https://github.com/compulim/react-wrap-with/pull10)

## Specific changes

> Please list each individual specific change in this pull request.

- Variable: `WrapperComponent` to `ContainerComponent`
- Variable: `WrappedComponent` to `ContentComponent`
- Type: `Wrapper` to `ContainerComponentProps`
- Type: `Wrapped` to `ContentComponentProps`
- Variable: `wrapperProps` to `initialProps`, to indicate that this is only used at initial time
