### PR TITLE
Props should be extracted when container is falsy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extracts props during render and pass to the wrapper component, by [@compulim](https://github.com/compulim), in PR [#4](https://github.com/compulim/react-wrap-with/pull/4) and [#5](https://github.com/compulim/react-wrap-with/pull/5)
 - Forwards ref to the inner component, by [@compulim](https://github.com/compulim), in PR [#8](https://github.com/compulim/react-wrap-with/pull/8)
 
+### Fixed
+
+- Fixes [#9](https://github.com/compulim/react-wrap-with/issues/9), props should be extracted even if container is falsy, by [@compulim](https://github.com/compulim), in PR [#11](https://github.com/compulim/react-wrap-with/pull/11)
+
 ### Changed
 
 - Terminology changed from "wrapper"/"wrapped" to "container"/"content", by [@compulim](https://github.com/compulim), in PR [#10](https://github.com/compulim/react-wrap-with/pull/10)

--- a/packages/react-wrap-with/src/wrapWith.extract.noContainer.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.extract.noContainer.spec.tsx
@@ -1,0 +1,20 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import wrapWith from './wrapWith';
+
+const Hello = ({ className }) => <h1 className={className}>Hello, World!</h1>;
+
+test('extract props without a container', () => {
+  // GIVEN: Wrapping <Hello> with false and extract "className" prop.
+  const BlinkingHello = wrapWith(false, {}, ['className'])(Hello);
+
+  // WHEN: Render.
+  const result = render(<BlinkingHello className="blink" />);
+
+  // THEN: It should produce HTML without class name because it is already extracted.
+  expect(result.container.innerHTML).toMatchInlineSnapshot(`"<h1>Hello, World!</h1>"`);
+});

--- a/packages/react-wrap-with/src/wrapWith.extract.noContainer.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.extract.noContainer.spec.tsx
@@ -2,11 +2,14 @@
 /// <reference types="@types/jest" />
 
 import { render } from '@testing-library/react';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import wrapWith from './wrapWith';
 
 const Hello = ({ className }) => <h1 className={className}>Hello, World!</h1>;
+
+Hello.propTypes = { className: PropTypes.string };
 
 test('extract props without a container', () => {
   // GIVEN: Wrapping <Hello> with false and extract "className" prop.

--- a/packages/react-wrap-with/src/wrapWith.refObject.classComponent.spec.tsx
+++ b/packages/react-wrap-with/src/wrapWith.refObject.classComponent.spec.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@types/jest" />
 
 import { render } from '@testing-library/react';
-import React, { Component, forwardRef, useEffect, useRef } from 'react';
+import React, { Component, useEffect, useRef } from 'react';
 
 import wrapWith from './wrapWith';
 

--- a/packages/react-wrap-with/src/wrapWith.tsx
+++ b/packages/react-wrap-with/src/wrapWith.tsx
@@ -97,7 +97,7 @@ export default function wrapWith<
 
     if (ContentComponent) {
       const WithContainer = forwardRef<Ref, PropsOf<ContentComponentType>>((props, ref) => {
-        const [_, contentProps] = pickAndOmit<
+        const [, contentProps] = pickAndOmit<
           Pick<PropsOf<ContainerComponentType>, ExtractPropKey>,
           PropsOf<ContentComponentType> & { ref?: Ref }
         >(props, extractPropKeys);

--- a/packages/react-wrap-with/src/wrapWith.tsx
+++ b/packages/react-wrap-with/src/wrapWith.tsx
@@ -96,9 +96,14 @@ export default function wrapWith<
     }
 
     if (ContentComponent) {
-      const WithContainer = forwardRef<Ref, PropsOf<ContentComponentType>>((props, ref) =>
-        createElement<PropsOf<ContentComponentType>>(ContentComponent, { ...props, ref })
-      );
+      const WithContainer = forwardRef<Ref, PropsOf<ContentComponentType>>((props, ref) => {
+        const [_, contentProps] = pickAndOmit<
+          Pick<PropsOf<ContainerComponentType>, ExtractPropKey>,
+          PropsOf<ContentComponentType> & { ref?: Ref }
+        >(props, extractPropKeys);
+
+        return createElement<PropsOf<ContentComponentType>>(ContentComponent, { ...contentProps, ref });
+      });
 
       WithContainer.displayName = ContentComponent.displayName;
 


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixes [#9](https://github.com/compulim/react-wrap-with/issues/9), props should be extracted when container is falsy, by [@compulim](https://github.com/compulim), in PR [#11](https://github.com/compulim/react-wrap-with/pull/11)

## Specific changes

> Please list each individual specific change in this pull request.

- Extract props when container is falsy