### PR TITLE
Fix generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added option to spy props of content component and pass it to container component, by [@compulim](https://github.com/compulim), in PR [#30](https://github.com/compulim/react-wrap-with/pull/30)
+- Added option to spy props of content component and pass it to container component, by [@compulim](https://github.com/compulim), in PR [#30](https://github.com/compulim/react-wrap-with/pull/30) and PR [#31](https://github.com/compulim/react-wrap-with/pull/31)
 
 ### Changed
 

--- a/packages/react-wrap-with/__tests__/types/generic.missing.tsx
+++ b/packages/react-wrap-with/__tests__/types/generic.missing.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { wrapWith } from '../../src/index';
+
+import type { PropsWithChildren } from 'react';
+
+type HeaderProps = PropsWithChildren<{ className: string; value?: string }>;
+
+const Header = ({ children, className }: HeaderProps) => <h1 className={className}>{children}</h1>;
+
+// @ts-expect-error Property 'className' is missing in type '{}' but required in type '{ className: unique symbol; value?: unique symbol | undefined; children?: undefined; }'.
+wrapWith<typeof Header, 'className', 'value'>(Header, {});

--- a/packages/react-wrap-with/__tests__/types/generic.tsx
+++ b/packages/react-wrap-with/__tests__/types/generic.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { Extract, Spy, wrapWith } from '../../src/index';
+
+import type { PropsWithChildren } from 'react';
+
+type HeaderProps = PropsWithChildren<{ className: string; value?: string }>;
+
+const Header = ({ children, className }: HeaderProps) => <h1 className={className}>{children}</h1>;
+
+wrapWith<typeof Header, 'className', 'value'>(Header, { className: Extract, value: Spy });

--- a/packages/react-wrap-with/__tests__/types/generic.wrongType.tsx
+++ b/packages/react-wrap-with/__tests__/types/generic.wrongType.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { Extract, wrapWith } from '../../src/index';
+
+import type { PropsWithChildren } from 'react';
+
+type HeaderProps = PropsWithChildren<{ className: string; value?: string }>;
+
+const Header = ({ children, className }: HeaderProps) => <h1 className={className}>{children}</h1>;
+
+// @ts-expect-error Type 'typeof Extract' is not assignable to type 'typeof Spy'.
+wrapWith<typeof Header, 'className', 'value'>(Header, { className: Extract, value: Extract });

--- a/packages/react-wrap-with/__tests__/types/generic.wrongType2.tsx
+++ b/packages/react-wrap-with/__tests__/types/generic.wrongType2.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { Spy, wrapWith } from '../../src/index';
+
+import type { PropsWithChildren } from 'react';
+
+type HeaderProps = PropsWithChildren<{ className: string; value?: string }>;
+
+const Header = ({ children, className }: HeaderProps) => <h1 className={className}>{children}</h1>;
+
+// @ts-expect-error Type 'typeof Spy' is not assignable to type 'typeof Extract'.
+wrapWith<typeof Header, 'className', 'value'>(Header, { className: Spy, value: Spy });

--- a/packages/react-wrap-with/src/private/wrapWith.tsx
+++ b/packages/react-wrap-with/src/private/wrapWith.tsx
@@ -16,8 +16,8 @@ const EmptyComponent = () => <Fragment />;
 export default function wrapWith<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ContainerComponentType extends ComponentType<PropsWithChildren<any>>,
-  ExtractPropKey extends keyof ContainerComponentType,
-  SpyPropKey extends keyof ContainerComponentType,
+  ExtractPropKey extends keyof PropsOf<ContainerComponentType>,
+  SpyPropKey extends keyof PropsOf<ContainerComponentType>,
   const How extends HowOf<PropsOf<ContainerComponentType>, ExtractPropKey, SpyPropKey> = HowOf<
     ContainerComponentType,
     ExtractPropKey,
@@ -63,8 +63,8 @@ export default function wrapWith<
 export default function wrapWith<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ContainerComponentType extends ComponentType<PropsWithChildren<any>>,
-  ExtractPropKey extends keyof ContainerComponentType,
-  SpyPropKey extends keyof ContainerComponentType,
+  ExtractPropKey extends keyof PropsOf<ContainerComponentType>,
+  SpyPropKey extends keyof PropsOf<ContainerComponentType>,
   const How extends HowOf<PropsOf<ContainerComponentType>, ExtractPropKey, SpyPropKey> = HowOf<
     ContainerComponentType,
     ExtractPropKey,


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Added option to spy props of content component and pass it to container component, by [@compulim](https://github.com/compulim), in PR [#30](https://github.com/compulim/react-wrap-with/pull/30) and PR [#31](https://github.com/compulim/react-wrap-with/pull/31)

## Specific changes

> Please list each individual specific change in this pull request.

- Updated `wrapWith` with correct generic type