### PR TITLE
Converge declarationDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added type-checking for test, by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/react-wrap-with/pull/20)
-- Updates `tsconfig.json` to extend from [`@tsconfig/strictest`](https://npmjs.com/package/@tsconfig/strictest), by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/react-wrap-with/pull/20)
+- Updated `tsconfig.json` to extend from [`@tsconfig/strictest`](https://npmjs.com/package/@tsconfig/strictest), by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/react-wrap-with/pull/20)
 - Cleaned up types, by [@compulim](https://github.com/compulim), in PR [#37](https://github.com/compulim/react-wrap-with/pull/37)
+- Converged type outputs folder to `/lib/commonjs/` and `/lib/esmodules/`, by [@compulim](https://github.com/compulim), in PR [#38](https://github.com/compulim/react-wrap-with/pull/38)
 - Bump dependencies, by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/react-wrap-with/pull/20), PR [#22](https://github.com/compulim/react-wrap-with/pull/22), and PR [#23](https://github.com/compulim/react-wrap-with/pull/23)
    - Production dependencies
       - [`@babel/runtime-corejs3@7.22.15`](https://npmjs.com/package/@babel/runtime-corejs3)

--- a/packages/react-wrap-with/package.json
+++ b/packages/react-wrap-with/package.json
@@ -8,57 +8,57 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./lib/esmodules-types/index.d.ts",
+        "types": "./lib/esmodules/index.d.ts",
         "default": "./lib/esmodules/index.js"
       },
       "require": {
-        "types": "./lib/commonjs-types/index.d.ts",
+        "types": "./lib/commonjs/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
     },
     "./Extract": {
       "import": {
-        "types": "./lib/esmodules-types/Extract.d.ts",
+        "types": "./lib/esmodules/Extract.d.ts",
         "default": "./lib/esmodules/Extract.js"
       },
       "require": {
-        "types": "./lib/commonjs-types/Extract.d.ts",
+        "types": "./lib/commonjs/Extract.d.ts",
         "default": "./lib/commonjs/Extract.js"
       }
     },
     "./Spy": {
       "import": {
-        "types": "./lib/esmodules-types/Spy.d.ts",
+        "types": "./lib/esmodules/Spy.d.ts",
         "default": "./lib/esmodules/Spy.js"
       },
       "require": {
-        "types": "./lib/commonjs-types/Spy.d.ts",
+        "types": "./lib/commonjs/Spy.d.ts",
         "default": "./lib/commonjs/Spy.js"
       }
     },
     "./withProps": {
       "import": {
-        "types": "./lib/esmodules-types/withProps.d.ts",
+        "types": "./lib/esmodules/withProps.d.ts",
         "default": "./lib/esmodules/withProps.js"
       },
       "require": {
-        "types": "./lib/commonjs-types/withProps.d.ts",
+        "types": "./lib/commonjs/withProps.d.ts",
         "default": "./lib/commonjs/withProps.js"
       }
     },
     "./wrapWith": {
       "import": {
-        "types": "./lib/esmodules-types/wrapWith.d.ts",
+        "types": "./lib/esmodules/wrapWith.d.ts",
         "default": "./lib/esmodules/wrapWith.js"
       },
       "require": {
-        "types": "./lib/commonjs-types/wrapWith.d.ts",
+        "types": "./lib/commonjs/wrapWith.d.ts",
         "default": "./lib/commonjs/wrapWith.js"
       }
     }
   },
   "main": "./lib/commonjs/index.js",
-  "typings": "./lib/commonjs-types/index.d.ts",
+  "typings": "./lib/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run build:babel:commonjs && npm run build:babel:esmodules && npm run build:typescript:commonjs && npm run build:typescript:esmodules",
     "build:babel:commonjs": "babel src --config-file ./babel.commonjs.config.json --extensions .ts,.tsx --out-dir ./lib/commonjs/",
@@ -105,7 +105,7 @@
     "@babel/plugin-transform-runtime": "^7.22.15",
     "@babel/preset-env": "^7.22.15",
     "@babel/preset-react": "^7.22.15",
-    "@babel/preset-typescript": "^7.22.15",
+    "@babel/presetcript": "^7.22.15",
     "@testing-library/react": "^14.0.0",
     "@tsconfig/recommended": "^1.0.2",
     "@tsconfig/strictest": "^2.0.2",

--- a/packages/react-wrap-with/package.json
+++ b/packages/react-wrap-with/package.json
@@ -105,7 +105,7 @@
     "@babel/plugin-transform-runtime": "^7.22.15",
     "@babel/preset-env": "^7.22.15",
     "@babel/preset-react": "^7.22.15",
-    "@babel/presetcript": "^7.22.15",
+    "@babel/preset-typescript": "^7.22.15",
     "@testing-library/react": "^14.0.0",
     "@tsconfig/recommended": "^1.0.2",
     "@tsconfig/strictest": "^2.0.2",

--- a/packages/react-wrap-with/src/tsconfig.declaration.commonjs.json
+++ b/packages/react-wrap-with/src/tsconfig.declaration.commonjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "../lib/commonjs-types/",
+    "declarationDir": "../lib/commonjs/",
     "module": "CommonJS",
     "moduleResolution": "Node10"
   },

--- a/packages/react-wrap-with/src/tsconfig.declaration.esmodules.json
+++ b/packages/react-wrap-with/src/tsconfig.declaration.esmodules.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "../lib/esmodules-types/",
+    "declarationDir": "../lib/esmodules/",
     "module": "ESNext",
     "moduleResolution": "Bundler"
   },


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Converged type outputs folder to `/lib/commonjs/` and `/lib/esmodules/`, by [@compulim](https://github.com/compulim), in PR [#38](https://github.com/compulim/react-wrap-with/pull/38)

## Specific changes

> Please list each individual specific change in this pull request.

- Converged declaration output directory to `/lib/commonjs/` and `/lib/esmodules/`