### PR TITLE
Export type-fest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Exported some types from `type-fest` to workaround [a TypeScript bug with monorepo](https://github.com/microsoft/TypeScript/issues/47663), by [@compulim](https://github.com/compulim), in PR [#42](https://github.com/compulim/react-wrap-with/pull/42)
+
 ## [0.0.3] - 2023-10-09
 ### Added
 - Added option to spy props of content component and pass it to container component, by [@compulim](https://github.com/compulim), in PR [#30](https://github.com/compulim/react-wrap-with/pull/30), PR [#31](https://github.com/compulim/react-wrap-with/pull/31) and PR [#34](https://github.com/compulim/react-wrap-with/pull/34)

--- a/packages/react-wrap-with/src/index.ts
+++ b/packages/react-wrap-with/src/index.ts
@@ -3,9 +3,11 @@ import Spy from './Spy';
 import withProps from './withProps';
 import wrapWith from './wrapWith';
 
+// Due to [a TypeScript bug with monorepo](https://github.com/microsoft/TypeScript/issues/47663), we need to export types from dependencies.
+import type { ConditionalKeys, Simplify } from 'type-fest';
 import type { HowOf } from './HowOf';
 import type { PropsOf } from './PropsOf';
 import type { RefOf } from './RefOf';
 
-export { Extract, Spy, withProps, wrapWith };
+export { ConditionalKeys, Extract, Simplify, Spy, withProps, wrapWith };
 export { type HowOf, type PropsOf, type RefOf };


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Exported some types from `type-fest` to workaround [a TypeScript bug with monorepo](https://github.com/microsoft/TypeScript/issues/47663), by [@compulim](https://github.com/compulim), in PR [#42](https://github.com/compulim/react-wrap-with/pull/42)

## Specific changes

> Please list each individual specific change in this pull request.

- Exported some typings from `type-fest`