### PR TITLE
Relax react@16.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-wrap-with-root",
-  "version": "0.0.5-0",
+  "version": "0.1.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-wrap-with-root",
-      "version": "0.0.5-0",
+      "version": "0.1.0-0",
       "license": "MIT",
       "workspaces": [
         "packages/react-wrap-with",
@@ -8993,15 +8993,15 @@
       }
     },
     "node_modules/use-ref-from": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/use-ref-from/-/use-ref-from-0.0.3.tgz",
-      "integrity": "sha512-+HY0IesN9DMuD0gnvGP3U2NTWYE+AwdCQnuuihpi5tNeFxQGPEcWH7b8ayvwElYJm6RcHsuo7lnVd+do02ghnQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/use-ref-from/-/use-ref-from-0.1.0.tgz",
+      "integrity": "sha512-PRjmfhUGUKghhOjKV1dBU66M7CASdb4NkMsaaWLdJA81yOZFlVL7Pi3O9aD+68pRh0VrRQjZfS6Ux3vPy1VhRg==",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.23.1",
-        "use-ref-from": "^0.0.3"
+        "@babel/runtime-corejs3": "^7.24.1",
+        "use-ref-from": "^0.1.0"
       },
       "peerDependencies": {
-        "react": ">=16.9.0"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -9327,7 +9327,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-wrap-with": "^0.0.0-0",
-        "use-ref-from": "^0.0.3"
+        "use-ref-from": "^0.1.0"
       },
       "devDependencies": {
         "@tsconfig/strictest": "^2.0.5",
@@ -9367,7 +9367,7 @@
         "typescript": "^5.4.3"
       },
       "peerDependencies": {
-        "react": ">=16.9.0"
+        "react": ">=16.8.0"
       }
     },
     "packages/react-wrap-with/node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wrap-with-root",
-  "version": "0.0.5-0",
+  "version": "0.1.0-0",
   "description": "",
   "private": true,
   "author": "William Wong (https://github.com/compulim)",

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -17,8 +17,8 @@
     "devDependencies": {
       "@testing-library/react": "^12",
       "@types/react": "^16",
-      "react": "16.9.0",
-      "react-test-renderer": "16.9.0"
+      "react": "16.8.0",
+      "react-test-renderer": "16.8.0"
     }
   },
   "switch:react:17": {

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -20,8 +20,8 @@
     "devDependencies": {
       "@types/react": "^16",
       "@types/react-dom": "^16",
-      "react": "16.9.0",
-      "react-dom": "16.9.0"
+      "react": "16.8.0",
+      "react-dom": "16.8.0"
     }
   },
   "switch:react:17": {
@@ -54,6 +54,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-wrap-with": "^0.0.0-0",
-    "use-ref-from": "^0.0.3"
+    "use-ref-from": "^0.1.0"
   }
 }

--- a/packages/react-wrap-with/package.json
+++ b/packages/react-wrap-with/package.json
@@ -102,9 +102,9 @@
     "devDependencies": {
       "@testing-library/react": "^12",
       "@types/react": "^16",
-      "react": "16.9.0",
-      "react-dom": "16.9.0",
-      "react-test-renderer": "16.9.0"
+      "react": "16.8.0",
+      "react-dom": "16.8.0",
+      "react-test-renderer": "16.8.0"
     }
   },
   "switch:react:17": {
@@ -147,7 +147,7 @@
     "typescript": "^5.4.3"
   },
   "peerDependencies": {
-    "react": ">=16.9.0"
+    "react": ">=16.8.0"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.24.1",


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Relaxed peer dependencies requirements to `rea.ct@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#55](https://github.com/compulim/react-wrap-with/pull/55)
- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#50](https://github.com/compulim/react-wrap-with/pull/50), [#52](https://github.com/compulim/react-wrap-with/pull/52), [#54](https://github.com/compulim/react-wrap-with/pull/54), and [#55](https://github.com/compulim/react-wrap-with/pull/55)
   - Development dependencies
      - [`use-ref-from@0.1.0`](https://npmjs.com/package/use-ref-from)

## Specific changes

> Please list each individual specific change in this pull request.

- Update `/packages/react-wrap-with/packages.json/peerDependencies/react` to `>=16.8.0`
- Update `use-ref-from@0.1.0`