### PR TITLE
Bump @types/react@18.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - [`typescript@5.5.2`](https://npmjs.com/package/typescript/v/5.5.2)
 - Added [ESLint import/export syntax](https://npmjs.com/package/eslint-plugin-import), in PR [#72](https://github.com/compulim/react-wrap-with/pull/72)
 - Added [`publint`](https://npmjs.com/package/publint), in PR [#72](https://github.com/compulim/react-wrap-with/pull/72)
-- Bumped dependencies, in PR [#74](https://github.com/compulim/react-wrap-with/pull/74)
+- Bumped dependencies, in PR [#74](https://github.com/compulim/react-wrap-with/pull/74) and [#75](https://github.com/compulim/react-wrap-with/pull/75)
   - Production dependencies
     - [`type-fest@4.26.1`](https://npmjs.com/package/type-fest/v/4.26.1)
   - Development dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -3689,7 +3689,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -11087,7 +11086,7 @@
         "@tsconfig/strictest": "^2.0.5",
         "@types/jest": "^29.5.13",
         "@types/node": "^22.7.5",
-        "@types/react": "^18.3.4",
+        "@types/react": "^18.3.11",
         "esbuild": "^0.24.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -11101,16 +11100,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "packages/react-wrap-with/node_modules/@types/react": {
-      "version": "18.3.4",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
-      "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
-      "dev": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
       }
     },
     "packages/react-wrap-with/node_modules/type-fest": {

--- a/packages/react-wrap-with/package.json
+++ b/packages/react-wrap-with/package.json
@@ -72,17 +72,11 @@
   },
   "switch:react-18": {
     "devDependencies": {
-      "@types/react": "^18.3.4",
+      "@types/react": "^18",
       "react": "18.0.0",
       "react-dom": "18.0.0",
       "react-test-renderer": "18.0.0"
     }
-  },
-  "pinDependencies": {
-    "@types/react": [
-      "^18.3.4",
-      "@types/react@18.3.5 is causing build break"
-    ]
   },
   "devDependencies": {
     "@babel/preset-env": "^7.25.8",
@@ -95,7 +89,7 @@
     "@tsconfig/strictest": "^2.0.5",
     "@types/jest": "^29.5.13",
     "@types/node": "^22.7.5",
-    "@types/react": "^18.3.4",
+    "@types/react": "^18.3.11",
     "esbuild": "^0.24.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/packages/react-wrap-with/src/private/wrapWith.tsx
+++ b/packages/react-wrap-with/src/private/wrapWith.tsx
@@ -79,8 +79,14 @@ export default function wrapWith<
     contentComponent: ComponentType<ContentProps>
   ): ComponentType<Simplify<PropsWithoutRef<PropsOf<typeof contentComponent> & ExtractProps> & RefAttributes<Ref>>> {
     const WithContainer = forwardRef<Ref, ExtractProps & ContentProps>((props, ref) => {
-      const [extractedProps, contentProps] = pickAndOmit<ExtractProps, ContentProps>(props, extractPropsKeys);
-      const spyProps = pick<ContentProps, keyof PropsOf<typeof contentComponent>>(props, spyPropsKeys);
+      const [extractedProps, contentProps] = pickAndOmit<ExtractProps, ContentProps>(
+        props as ExtractProps & ContentProps, // "props" do not have "ref", we will assign it below.
+        extractPropsKeys
+      );
+      const spyProps = pick<ContentProps, keyof PropsOf<typeof contentComponent>>(
+        props as ExtractProps & ContentProps, // "props" do not have "ref" but spy will never have "ref" either.
+        spyPropsKeys
+      );
 
       return createElement(
         containerComponent,


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Bumped dependencies, in PR [#74](https://github.com/compulim/react-wrap-with/pull/74) and [#75](https://github.com/compulim/react-wrap-with/pull/75)
  - Development dependencies
    - [`@types/react@18.3.11`](https://npmjs.com/package/@types/react/v/18.3.11)

## Specific changes

> Please list each individual specific change in this pull request.

- Updated `wrapWith` to handle changes from `PropsWithoutRef`